### PR TITLE
Table.to_csv Zip Compression

### DIFF
--- a/docs/table.rst
+++ b/docs/table.rst
@@ -26,10 +26,10 @@ From Parsons Table
       - Return a Pandas dataframe
     * - ``.to_csv()``
       - CSV File
-      - Write a table to a local CSV file
+      - Write a table to a local csv file
     * - ``.to_s3_csv()``
       - AWS s3 Bucket
-      - A csv written to an s3 bucket
+      - Write a table to a csv stored in S3
     * - ``.to_redshift()``
       - A Redshift Database
       - Write a table to a Redshift database
@@ -38,7 +38,7 @@ From Parsons Table
       - Write table to a Civis Redshift Database using Civis Client
     * - ``.to_petl()``
       - Petl table object
-      - Return a Petl table object
+      - Convert a table a Petl table object
     * - ``.to_json()``
       - JSON file
       - Write a table to a local JSON file

--- a/docs/table.rst
+++ b/docs/table.rst
@@ -21,21 +21,23 @@ From Parsons Table
     * - Method
       - Destination Type
       - Description
-    * - ``.to_dataframe()``
-      - Dataframe
-      - Return a Pandas dataframe
     * - ``.to_csv()``
       - CSV File
       - Write a table to a local csv file
     * - ``.to_s3_csv()``
       - AWS s3 Bucket
       - Write a table to a csv stored in S3
+    * - ``.to_sftp_csv()``
+      - Write a table to a csv stored on an SFTP server
     * - ``.to_redshift()``
       - A Redshift Database
       - Write a table to a Redshift database
     * - ``.to_civis()``
       - Civis Redshift Database
-      - Write table to a Civis Redshift Database using Civis Client
+      - Write a table to Civis platform database
+    * - ``.to_dataframe()``
+      - Dataframe
+      - Return a Pandas dataframe
     * - ``.to_petl()``
       - Petl table object
       - Convert a table a Petl table object

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -213,7 +213,7 @@ class ToFrom(object):
         if not csv_name:
             csv_name = files.extract_file_name(archive_path) + '.csv'
 
-        return zip_archive.create_archive(archive_path, cf, file_name=csv_name, 
+        return zip_archive.create_archive(archive_path, cf, file_name=csv_name,
                                           if_exists=if_exists)
 
     def to_json(self, local_path=None, temp_file_compression=None, line_delimited=False):

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -85,9 +85,9 @@ class ToFrom(object):
     def to_csv(self, local_path=None, temp_file_compression=None, encoding=None, errors='strict',
                write_header=True, **csvargs):
         """
-        Outputs table to a CSV. Additional additional key word arguments are passed
-        to ``csv.writer()``. So, e.g., to override the delimiter from the default CSV dialect,
-        provide the delimiter keyword argument.
+        Outputs table to a CSV. Additional key word arguments are passed to ``csv.writer()``. So,
+        e.g., to override the delimiter from the default CSV dialect, provide the delimiter
+        keyword argument.
 
         .. warning::
                 If a file already exists at the given location, it will be
@@ -173,16 +173,16 @@ class ToFrom(object):
     def to_zip_csv(self, archive_path=None, csv_name=None, encoding=None,
                    errors='strict', write_header=True, if_exists='replace', **csvargs):
         """
-        Outputs table to a CSV in a zip archive. Additional additional key word arguments
-        are passed to ``csv.writer()``. So, e.g., to override the delimiter
-        from the default CSV dialect, provide the delimiter keyword argument. Use this
-        method if you would like to write multiple csv files to the same archive.
+        Outputs table to a CSV in a zip archive. Additional key word arguments are passed to
+        ``csv.writer()``. So, e.g., to override the delimiter from the default CSV dialect,
+        provide the delimiter keyword argument. Use thismethod if you would like to write
+        multiple csv files to the same archive.
 
         .. warning::
                 If a file already exists in the archive, it will be overwritten.
         `Args:`
             archive_path: str
-                The path to zip achive.If not specified, a temporary file will be created and
+                The path to zip achive. If not specified, a temporary file will be created and
                 returned, and that file will be removed automatically when the script is done
                 running.
             csv_name: str
@@ -337,7 +337,8 @@ class ToFrom(object):
             aws_secret_access_key: str
                 Required if not included as environmental variable
             compression: str
-                The compression type for the s3 object. Currently "None", "gzip" are supported.
+                The compression type for the s3 object. Currently "None", "zip" and "gzip" are
+                supported.
             encoding: str
                 The CSV encoding type for `csv.writer()
                 <https://docs.python.org/2/library/csv.html#csv.writer/>`_

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -85,8 +85,8 @@ class ToFrom(object):
     def to_csv(self, local_path=None, temp_file_compression=None, encoding=None, errors='strict',
                write_header=True, **csvargs):
         """
-        Outputs table to a CSV. Additional additional key word arguments are passed 
-        to ``csv.writer()``. So, e.g., to override the delimiter from the default CSV dialect, 
+        Outputs table to a CSV. Additional additional key word arguments are passed
+        to ``csv.writer()``. So, e.g., to override the delimiter from the default CSV dialect,
         provide the delimiter keyword argument.
 
         .. warning::
@@ -175,7 +175,7 @@ class ToFrom(object):
         """
         Outputs table to a CSV in a zip archive. Additional additional key word arguments
         are passed to ``csv.writer()``. So, e.g., to override the delimiter
-        from the default CSV dialect, provide the delimiter keyword argument. Use this 
+        from the default CSV dialect, provide the delimiter keyword argument. Use this
         method if you would like to write multiple csv files to the same archive.
 
         .. warning::
@@ -337,7 +337,7 @@ class ToFrom(object):
             aws_secret_access_key: str
                 Required if not included as environmental variable
             compression: str
-                The compression type for the s3 object. Currently "None" and "gzip" are supported.
+                The compression type for the s3 object. Currently "None", "gzip" are supported.
             encoding: str
                 The CSV encoding type for `csv.writer()
                 <https://docs.python.org/2/library/csv.html#csv.writer/>`_

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -2,7 +2,7 @@ import petl
 import json
 import io
 import gzip
-from parsons.utilities import files
+from parsons.utilities import files, zip_archive
 
 
 class ToFrom(object):
@@ -161,6 +161,47 @@ class ToFrom(object):
                        errors=errors,
                        **csvargs)
         return local_path
+
+    def to_zip_csv(self, archive_path=None, csv_name=None, encoding=None,
+                   errors='strict', write_header=True, if_exists='replace', **csvargs):
+        """
+        Outputs table to a CSV in a zip archive. Additional additional key word arguments
+        are passed to ``csv.writer()``. So, e.g., to override the delimiter
+        from the default CSV dialect, provide the delimiter keyword argument.
+
+        .. warning::
+                If a file already exists in the archive, it will be overwritten.
+        `Args:`
+            archive_path: str
+                The path to zip achive.If not specified, a temporary file will be created and
+                returned, and that file will be removed automatically when the script is done
+                running.
+            csv_name: str
+                The name of the csv file to be stored in the archive
+            encoding: str
+                The CSV encoding type for `csv.writer()
+                <https://docs.python.org/2/library/csv.html#csv.writer/>`_
+            errors: str
+                Raise an Error if encountered
+            write_header: boolean
+                Include header in output
+            if_exists: str
+                If archive already exists, one of 'replace' or 'append'
+            **csvargs: kwargs
+                ``csv_writer`` optional arguments
+
+        `Returns:`
+            str
+                The path of the archive
+        """
+
+        if not archive_path:
+            archive_path = files.create_temp_file(suffix='.zip')
+
+        cf = self.to_csv(encoding=encoding, errors=errors, write_header=write_header, **csvargs)
+
+        return zip_archive.create_archive(archive_path, cf, file_name=csv_name,
+                                          if_exists=if_exists)
 
     def to_json(self, local_path=None, temp_file_compression=None, line_delimited=False):
         """

--- a/parsons/utilities/files.py
+++ b/parsons/utilities/files.py
@@ -134,6 +134,7 @@ def string_to_temp_file(string, suffix=None):
 
     return temp_file_path
 
+
 def zip_check(file_path, compression_type):
     """
     Check if the file suffix or the compression type indicates that it is
@@ -149,6 +150,7 @@ def zip_check(file_path, compression_type):
 
     else:
         return False
+
 
 def extract_file_name(file_path=None):
     """

--- a/parsons/utilities/files.py
+++ b/parsons/utilities/files.py
@@ -133,3 +133,29 @@ def string_to_temp_file(string, suffix=None):
         f.write(string)
 
     return temp_file_path
+
+def zip_check(file_path, compression_type):
+    """
+    Check if the file suffix or the compression type indicates that it is
+    a zip file.
+    """
+
+    if file_path:
+        if file_path.split('/')[-1].split('.')[-1] == 'zip':
+            return True
+
+    if compression_type == 'zip':
+        return True
+
+    else:
+        return False
+
+def extract_file_name(file_path=None):
+    """
+    Extract the file name without the suffix from a file path string.
+    """
+
+    if not file_path:
+        return None
+
+    return file_path.split('/')[-1].split('.')[0]

--- a/parsons/utilities/zip_archive.py
+++ b/parsons/utilities/zip_archive.py
@@ -4,10 +4,12 @@ import zipfile
 def create_archive(archive_path, file_path, file_name=None, if_exists='replace'):
     """
     `Args:`
-        archive_name: str
+        archive_path: str
             The file name of zip archive
-        csv_path: str
+        file_path: str
             The path of the file
+        file_name: str
+            The name of the file in the archive
         if_exists: str
             If archive already exists, one of 'replace' or 'append'
     `Returns:`

--- a/parsons/utilities/zip_archive.py
+++ b/parsons/utilities/zip_archive.py
@@ -1,0 +1,28 @@
+import zipfile
+
+
+def create_archive(archive_path, file_path, file_name=None, if_exists='replace'):
+    """
+    `Args:`
+        archive_name: str
+            The file name of zip archive
+        csv_path: str
+            The path of the file
+        if_exists: str
+            If archive already exists, one of 'replace' or 'append'
+    `Returns:`
+        Zip archive path
+    """
+
+    if if_exists == 'append':
+        write_type = 'a'
+    else:
+        write_type = 'w'
+
+    if not file_name:
+        file_name = file_path.split('/')[-1]
+
+    with zipfile.ZipFile(archive_path, write_type) as z:
+        z.write(file_path, arcname=file_name, compress_type=zipfile.ZIP_STORED)
+
+    return archive_path

--- a/parsons/utilities/zip_archive.py
+++ b/parsons/utilities/zip_archive.py
@@ -3,6 +3,8 @@ import zipfile
 
 def create_archive(archive_path, file_path, file_name=None, if_exists='replace'):
     """
+    Create and fill an archive.
+
     `Args:`
         archive_path: str
             The file name of zip archive
@@ -28,3 +30,16 @@ def create_archive(archive_path, file_path, file_name=None, if_exists='replace')
         z.write(file_path, arcname=file_name, compress_type=zipfile.ZIP_STORED)
 
     return archive_path
+
+def unzip_archive(archive_path):
+    """
+    Unzip an archive.
+
+    `Args:`
+        archive_path: str
+    `Returns:`
+        ``None``
+    """
+
+    with zipfile.ZipFile(archive_path, 'r') as z:
+        z.extractall()

--- a/parsons/utilities/zip_archive.py
+++ b/parsons/utilities/zip_archive.py
@@ -31,6 +31,7 @@ def create_archive(archive_path, file_path, file_name=None, if_exists='replace')
 
     return archive_path
 
+
 def unzip_archive(archive_path):
     """
     Unzip an archive.

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -5,6 +5,7 @@ import pandas
 import os
 import shutil
 from test.utils import assert_matching_tables
+from parsons.utilities import zip_archive
 
 
 class TestParsonsTable(unittest.TestCase):
@@ -206,6 +207,18 @@ class TestParsonsTable(unittest.TestCase):
         open(path, 'a').close()
 
         self.assertRaises(ValueError, Table.from_csv, path)
+
+    def test_to_csv_zip(self):
+
+        # Test using the to_csv() method
+        self.tbl.to_csv('myzip.zip')
+        zip_archive.unzip_archive('myzip.zip')
+        assert_matching_tables(self.tbl, Table.from_csv('myzip.csv'))
+
+        # Test using the to_csv_zip() method
+        self.tbl.to_zip_csv('myzip.zip')
+        zip_archive.unzip_archive('myzip.zip')
+        assert_matching_tables(self.tbl, Table.from_csv('myzip.csv'))
 
     def test_to_civis(self):
 

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -4,11 +4,6 @@ from parsons.etl.table import Table
 import pandas
 import os
 import shutil
-import _io
-import io
-import json
-import datetime
-import gzip
 from test.utils import assert_matching_tables
 
 


### PR DESCRIPTION
- Add compression type `.zip` to `Table.to_csv()` method.
- Add stand alone `Table.to_csv_zip()` method that allows for the specification of the file name and the ability to append to an existing archive.