### PR TITLE
VAN: Add ID to find_person() and upsert_person()

### DIFF
--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -1,4 +1,5 @@
 from parsons.utilities import json_format
+from parsons.utilities.converted_dict import converted_dict
 import logging
 
 logger = logging.getLogger(__name__)
@@ -10,9 +11,9 @@ class People(object):
 
         self.connection = van_connection
 
-    def find_person(self, id=None, id_type=None, expand_fields=None, firstName=None, lastName=None,
-                    dateOfBirth=None, email=None, phone=None, address1=None, zip=None,
-                    match_map=None):
+    def find_person(self, id=None, id_type=None, expand_fields=None, first_name=None,
+                    last_name=None, date_of_birth=None, email=None, phone_number=None,
+                    address_line1=None, zip=None, match_map=None):
         """
         Find a person record.
 
@@ -20,10 +21,10 @@ class People(object):
             Person find must include VAN ID or one the following minimum combinations
             to conduct a search.
 
-            - firstName, lastName, email
-            - firstName, lastName, phone
-            - firstName, lastName, zip5, dateOfBirth
-            - firstName, lastName, street_number, street_name, zip5
+            - first_name, last_name, email
+            - first_name, last_name, phone_number
+            - first_name, last_name, zip5, date_of_birth
+            - first_name, last_name, street_number, street_name, zip5
             - email_address
 
         .. note::
@@ -44,17 +45,17 @@ class People(object):
                 List of nested fields to expand for full data (e.g. emails, addresses, etc.)
                 Only relevant if `id` is provided, defaults to all expandable fields
                 - see `VAN docs <https://developers.ngpvan.com/van-api#people-get-people--vanid>`_.
-            firstName: str
+            first_name: str
                 The person's first name
-            lastName: str
+            last_name: str
                 The person's last name
             dob: str
                 ISO 8601 formatted date of birth (e.g. ``1981-02-01``)
             email: str
                 The person's email address
-            phone: str
+            phone_number: str
                 Phone number of any type (Work, Cell, Home)
-            address1: str
+            address_line1: str
                 Must contain Street Number and Street Name
             zip: str
                 5 digit zip code
@@ -66,24 +67,24 @@ class People(object):
                 See :ref:`parsons-table` for output options.
         """
 
-        logger.info(f'Finding {firstName} {lastName}.')
+        logger.info(f'Finding {first_name} {last_name}.')
 
-        return self._people_search(id, id_type, expand_fields, firstName, lastName, dateOfBirth,
-                                   email, phone, address1, zip, match_map)
+        return self._people_search(id, id_type, expand_fields, first_name, last_name, date_of_birth,
+                                   email, phone_number, address_line1, zip, match_map)
 
-    def upsert_person(self, id=None, id_type=None, firstName=None, lastName=None, dateOfBirth=None,
-                      email=None, phone=None, address1=None, zip=None,
-                      match_map=None):
+    def upsert_person(self, id=None, id_type=None, first_name=None, last_name=None,
+                      date_of_birth=None, email=None, phone_number=None, address_line1=None,
+                      zip=None, match_map=None):
         """
         Create or update a person record.
 
         .. note::
             Person find must include VAN ID or one of the following minimum combinations.
 
-            - firstName, lastName, email
-            - firstName, lastName, phone
-            - firstName, lastName, zip5, dateOfBirth
-            - firstName, lastName, street_number, street_name, zip5
+            - first_name, last_name, email
+            - first_name, last_name, phone_number
+            - first_name, last_name, zip5, date_of_birth
+            - first_name, last_name, street_number, street_name, zip5
             - email_address
 
         .. note::
@@ -100,17 +101,17 @@ class People(object):
                 Any of the record's unique identifiers (e.g. VAN ID) if already known
             id_type: str
                 If `id` is provided, this is the person ID type (defaults to 'vanid')
-            firstName: str
+            first_name: str
                 The person's first name
-            lastName: str
+            last_name: str
                 The person's last name
             dob: str
                 ISO 8601 formatted date of birth (e.g. ``1981-02-01``)
             email: str
                 The person's email address
-            phone: str
+            phone_number: str
                 Phone number of any type (Work, Cell, Home)
-            address1: str
+            address_line1: str
                 Must contain Street Number and Street Name
             zip: str
                 5 digit zip code
@@ -122,32 +123,34 @@ class People(object):
                 See :ref:`parsons-table` for output options.
         """
 
-        return self._people_search(id, id_type, None, firstName, lastName, dateOfBirth, email,
-                                   phone, address1, zip, match_map, create=True)
+        return self._people_search(id, id_type, None, first_name, last_name, date_of_birth, email,
+                                   phone_number, address_line1, zip, match_map, create=True)
 
-    def _people_search(self, id=None, id_type=None, expand_fields=None, firstName=None,
-                       lastName=None, dateOfBirth=None, email=None, phone=None,
-                       addressLine1=None, zipOrPostalCode=None, match_map=None, create=False):
+    def _people_search(self, id=None, id_type=None, expand_fields=None, first_name=None,
+                       last_name=None, date_of_birth=None, email=None, phone_number=None,
+                       address_line1=None, zip_or_postal_code=None, match_map=None, create=False):
         # Internal method to hit the people find/create endpoints
 
         # Check to see if a match map has been provided
         if match_map is None:
             match_map = {}
-        match_map.update({"firstName": firstName, "lastName": lastName})
+        match_map.update({"first_name": first_name, "last_name": last_name})
 
         # Will fail if empty dicts are provided, hence needed to add if exist
         if email is not None:
             match_map['emails'] = [{'email': email}]
-        if phone is not None:  # To Do: Strip out non-integers from phone
-            match_map['phones'] = [{'phoneNumber': phone}]
-        if dateOfBirth is not None:
-            match_map['dateOfBirth'] = dateOfBirth
-        if zipOrPostalCode is not None:
-            match_map['addresses'] = [{'zipOrPostalCode': zipOrPostalCode}]
-        if addressLine1 is not None:
-            match_map['addresses'][0]['addressLine1'] = addressLine1
+        if phone_number is not None:  # To Do: Strip out non-integers from phone
+            match_map['phones'] = [{'phone_number': phone_number}]
+        if date_of_birth is not None:
+            match_map['date_of_birth'] = date_of_birth
+        if zip_or_postal_code is not None or address_line1 is not None:
+            match_map['addresses'] = []
+            if zip_or_postal_code is not None:
+                match_map['addresses'][0]['address_line1'] = address_line1
+            if address_line1 is not None:
+                match_map['addresses'][0]['zip_or_postal_code'] = zip_or_postal_code
 
-        json = match_map
+        json = converted_dict(match_map, json_format.arg_format).result
         # Check if VANID actually supplied in match_map
         if 'vanid' in [k.lower() for k in match_map]:
             id = {k.lower(): v for k, v in match_map.items()}['vanid']
@@ -215,10 +218,10 @@ class People(object):
             raise ValueError("""
                              Person find must include the following minimum
                              combinations to conduct a search.
-                                - firstName, lastName, email
-                                - firstName, lastName, phone
-                                - firstName, lastName, zip, dob
-                                - firstName, lastName, street_number, street_name, zip
+                                - first_name, last_name, email
+                                - first_name, last_name, phone
+                                - first_name, last_name, zip, dob
+                                - first_name, last_name, street_number, street_name, zip
                                 - email
                             """)
 

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -149,7 +149,7 @@ class People(object):
 
         json = match_map
         # Check if VANID actually supplied in match_map
-        if 'id' in [k.lower() for k in match_map]:
+        if 'vanid' in [k.lower() for k in match_map]:
             id = {k.lower(): v for k, v in match_map.items()}['vanid']
 
         if id is None:

--- a/parsons/utilities/converted_dict.py
+++ b/parsons/utilities/converted_dict.py
@@ -1,0 +1,31 @@
+class converted_dict(object):
+    # For when you need to apply a consistent transformation to all the keys
+    # in a dictionary, including the keys of embedded dictionaries within.
+    # The conversion_function must take the string as argument
+
+    def __init__(self, dct, conversion_function, kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+        self.result = self.key_converter(dct, conversion_function, kwargs)
+
+    def key_converter(self, dct, conversion_function, kwargs):
+        final_dct = {}
+        for k, v in dct.items():
+            final_val = v
+            if isinstance(v, dict):
+                final_val = self.key_converter(v, conversion_function, kwargs)
+            elif isinstance(v, list):
+                final_val = self.list_loop(v, conversion_function, kwargs)
+            final_key = conversion_function(k, *kwargs)
+            final_dct[final_key] = final_val
+        return final_dct
+
+    def list_loop(self, lst, conversion_function, kwargs):
+        dicts = [x for x in lst if isinstance(x, dict)]
+        lists = [x for x in lst if isinstance(x, list)]
+        final_lst = [x for x in lst if x not in dicts and x not in lists]
+        for d in dicts:
+            final_lst.append(self.key_converter(d, conversion_function, kwargs))
+        for l in lists:
+            final_lst.append(self.list_loop(l, conversion_function, kwargs))
+        return final_lst

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -6,6 +6,7 @@ from parsons.utilities import date_convert
 from parsons.utilities import files
 from parsons.utilities import check_env
 from parsons.utilities import json_format
+from parsons.utilities import converted_dict
 
 
 """
@@ -55,6 +56,15 @@ def test_compression_type_for_path():
 
 def test_json_format():
     assert json_format.arg_format('my_arg') == 'myArg'
+
+def test_converted_dict():
+    dct = {"ak": 1, "aak": ["a", "aa", {"aaak": 3}, {"aaaak": 4},
+        {"aaaaak": ["aaa", "aaaa"]}], "aaaaaak": {"aaaaaaak": 7}}
+    
+    def remove_a(string):
+        return string.replace("a", "")
+
+    assert not "a" in converted_dict.converted_dict(dct, remove_a).result
 
 class TestCheckEnv(unittest.TestCase):
 

--- a/test/test_van/test_people.py
+++ b/test/test_van/test_people.py
@@ -57,7 +57,6 @@ class TestNGPVAN(unittest.TestCase):
         # Successful with FN/LN/DOB/ZIP
         del json['emails']
         json.update({"addresses": [{"zipOrPostalCode": 60615}], "dateOfBirth": '1961-08-04'})
-        print(json)
         self.van._valid_search(json)
 
         # Successful with FN/LN/Phone

--- a/test/test_van/test_people.py
+++ b/test/test_van/test_people.py
@@ -20,7 +20,8 @@ class TestNGPVAN(unittest.TestCase):
 
         m.post(self.van.connection.uri + 'people/find', json=json)
 
-        person = self.van.find_person(firstName='Bob', lastName='Smith', phone=4142020792)
+        person = self.van.find_person(first_name='Bob', last_name='Smith',
+            phone_number=4142020792)
 
         self.assertEqual(person, json)
 
@@ -56,6 +57,7 @@ class TestNGPVAN(unittest.TestCase):
         # Successful with FN/LN/DOB/ZIP
         del json['emails']
         json.update({"addresses": [{"zipOrPostalCode": 60615}], "dateOfBirth": '1961-08-04'})
+        print(json)
         self.van._valid_search(json)
 
         # Successful with FN/LN/Phone

--- a/test/test_van/test_people.py
+++ b/test/test_van/test_people.py
@@ -20,7 +20,7 @@ class TestNGPVAN(unittest.TestCase):
 
         m.post(self.van.connection.uri + 'people/find', json=json)
 
-        person = self.van.find_person(first_name='Bob', last_name='Smith', phone=4142020792)
+        person = self.van.find_person(firstName='Bob', lastName='Smith', phone=4142020792)
 
         self.assertEqual(person, json)
 
@@ -36,28 +36,33 @@ class TestNGPVAN(unittest.TestCase):
     def test_valid_search(self):
 
         # Fails with FN / LN Only
-        self.assertRaises(ValueError, self.van._valid_search, 'Barack',
-                          'Obama', None, None, None, None, None, None, None)
+        json = {"firstName": "Barack", "lastName": "Obama"}
+        self.assertRaises(ValueError, self.van._valid_search, json)
 
         # Fails with only Zip
-        self.assertRaises(ValueError, self.van._valid_search, 'Barack',
-                          'Obama', None, None, None, None, None, 60622, None)
+        json.update({"addresses": [{"zipOrPostalCode": 60615}]})
+        self.assertRaises(ValueError, self.van._valid_search, json)
 
-        # Fails with no street number
-        self.assertRaises(ValueError, self.van._valid_search, 'Barack',
-                          'Obama', None, None, None, None, 'Pennsylvania Ave', None, None)
+        # Fails with street address but no Zip
+        del json['addresses'][0]['zipOrPostalCode']
+        json['addresses'][0].update({"addressLine1": "5042 S. Woodlawn Ave."})
+        self.assertRaises(ValueError, self.van._valid_search, json)
 
         # Successful with FN/LN/Email
-        self.van._valid_search('Barack', 'Obama', 'barack@email.com', None, None, None,
-                               None, None, None)
+        del json['addresses']
+        json.update({"emails": [{"email": "barack@email.com"}]})
+        self.van._valid_search(json)
 
         # Successful with FN/LN/DOB/ZIP
-        self.van._valid_search('Barack', 'Obama', 'barack@email.com', None, None, '2000-01-01',
-                               None, 20009, None)
+        del json['emails']
+        json.update({"addresses": [{"zipOrPostalCode": 60615}], "dateOfBirth": '1961-08-04'})
+        self.van._valid_search(json)
 
         # Successful with FN/LN/Phone
-        self.van._valid_search('Barack', 'Obama', None, 2024291000, None, None,
-                               None, None, None)
+        del json['addresses']
+        del json['dateOfBirth']
+        json.update({"phones": [{"phoneNumber": 2024291000}]})
+        self.van._valid_search(json)
 
     @requests_mock.Mocker()
     def test_get_person(self, m):


### PR DESCRIPTION
@jburchard besides passing the tests I adapted in `test_people.py`, I've tested this functionality in the following scenarios, and include results:

Able to find myself without error, using all of the following:
- `van.find_person(id=100520240)`
- `van.find_person(firstName="Yotam", lastName="Amit", email="paxarchy@gmail.com")`
- `van.find_person(id=100520240, firstName='Yotam')`
- `van.find_person(match_map={"vanid": 100520240})`

Able to update my data with both of the following:
- `van.upsert_person(id=100520240, match_map={"middleName": "David"})`
- `van.upsert_person(firstName="Yotam", lastName="Amit", email=MY EMAIL, match_map={"dateOfBirth": "1984-08-03"})`