### PR TITLE
Redshift copy col list

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -332,7 +332,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftQueries, Redshift
                 leftover target table columns filled in with the `DEFAULT` value.
                 .. warning::
                    This will only work if the provided column names all have _exact_ matches
-                   in the target table. This will also fail if the target table has an `IDENTITY` 
+                   in the target table. This will also fail if the target table has an `IDENTITY`
                    column and that column name is among the provided columns.
             aws_access_key_id:
                 An AWS access key granted to the bucket where the file is located. Not required
@@ -455,7 +455,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftQueries, Redshift
                 leftover target table columns filled in with the `DEFAULT` value.
                 .. warning::
                    This will only work if the source table's column names all have _exact_ matches
-                   in the target table. This will also fail if the target table has an `IDENTITY` 
+                   in the target table. This will also fail if the target table has an `IDENTITY`
                    column and that column name is among the source table's columns.
             aws_access_key_id:
                 An AWS access key granted to the bucket where the file is located. Not required

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -392,7 +392,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftQueries, Redshift
              sortkey=None, padding=None, statupdate=False, compupdate=True, acceptanydate=True,
              emptyasnull=True, blanksasnull=True, nullas=None, acceptinvchars=True,
              dateformat='auto', timeformat='auto', varchar_max=None, truncatecolumns=False,
-             columntypes=None, specifycols=False
+             columntypes=None, specifycols=False,
              aws_access_key_id=None, aws_secret_access_key=None):
         """
         Copy a parsons table object to Redshift.

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -326,7 +326,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftQueries, Redshift
                 Optional map of column name to redshift column type, overriding the usual type
                 inference. You only specify the columns you want to override, eg.
                 ``columntypes={'phone': 'varchar(12)', 'age': 'int'})``.
-            specifycols: boolean
+            specifycols: list
                 Adds a column list to the Redshift `COPY` command, allowing for the source file
                 in an append to have the columnns out of order, and to have fewer columns with any
                 leftover target table columns filled in with the `DEFAULT` value.

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -257,7 +257,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftQueries, Redshift
                 statupdate=True, compupdate=True, ignoreheader=1, acceptanydate=True,
                 dateformat='auto', timeformat='auto', emptyasnull=True,
                 blanksasnull=True, nullas=None, acceptinvchars=True, truncatecolumns=False,
-                columntypes=None,
+                columntypes=None, specifycols=None,
                 aws_access_key_id=None, aws_secret_access_key=None):
         """
         Copy a file from s3 to Redshift.
@@ -326,6 +326,14 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftQueries, Redshift
                 Optional map of column name to redshift column type, overriding the usual type
                 inference. You only specify the columns you want to override, eg.
                 ``columntypes={'phone': 'varchar(12)', 'age': 'int'})``.
+            specifycols: boolean
+                Adds a column list to the Redshift `COPY` command, allowing for the source file
+                in an append to have the columnns out of order, and to have fewer columns with any
+                leftover target table columns filled in with the `DEFAULT` value.
+                .. warning::
+                   This will only work if the provided column names all have _exact_ matches
+                   in the target table. This will also fail if the target table has an `IDENTITY` 
+                   column and that column name is among the provided columns.
             aws_access_key_id:
                 An AWS access key granted to the bucket where the file is located. Not required
                 if keys are stored as environmental variables.
@@ -374,6 +382,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftQueries, Redshift
                                            emptyasnull=emptyasnull, blanksasnull=blanksasnull,
                                            nullas=nullas, acceptinvchars=acceptinvchars,
                                            truncatecolumns=truncatecolumns,
+                                           specifycols=specifycols,
                                            dateformat=dateformat, timeformat=timeformat)
 
             self.query_with_connection(copy_sql, connection, commit=False)
@@ -383,7 +392,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftQueries, Redshift
              sortkey=None, padding=None, statupdate=False, compupdate=True, acceptanydate=True,
              emptyasnull=True, blanksasnull=True, nullas=None, acceptinvchars=True,
              dateformat='auto', timeformat='auto', varchar_max=None, truncatecolumns=False,
-             columntypes=None,
+             columntypes=None, specifycols=False
              aws_access_key_id=None, aws_secret_access_key=None):
         """
         Copy a parsons table object to Redshift.
@@ -440,6 +449,14 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftQueries, Redshift
                 Optional map of column name to redshift column type, overriding the usual type
                 inference. You only specify the columns you want to override, eg.
                 ``columntypes={'phone': 'varchar(12)', 'age': 'int'})``.
+            specifycols: boolean
+                Adds a column list to the Redshift `COPY` command, allowing for the source table
+                in an append to have the columnns out of order, and to have fewer columns with any
+                leftover target table columns filled in with the `DEFAULT` value.
+                .. warning::
+                   This will only work if the source table's column names all have _exact_ matches
+                   in the target table. This will also fail if the target table has an `IDENTITY` 
+                   column and that column name is among the source table's columns.
             aws_access_key_id:
                 An AWS access key granted to the bucket where the file is located. Not required
                 if keys are stored as environmental variables.
@@ -457,6 +474,10 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftQueries, Redshift
 
         key = self.temp_s3_copy(table_obj)
 
+        cols = None
+        if specifycols:
+            cols = table_obj.columns
+
         try:
 
             self.copy_s3(table_name, self.s3_temp_bucket, key,
@@ -466,7 +487,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftQueries, Redshift
                          acceptanydate=acceptanydate, dateformat=dateformat, timeformat=timeformat,
                          blanksasnull=blanksasnull, nullas=nullas, emptyasnull=emptyasnull,
                          acceptinvchars=acceptinvchars, truncatecolumns=truncatecolumns,
-                         columntypes=columntypes,
+                         columntypes=columntypes, specifycols=cols,
                          aws_access_key_id=aws_access_key_id,
                          aws_secret_access_key=aws_secret_access_key, compression='gzip')
 

--- a/parsons/databases/redshift/rs_copy_table.py
+++ b/parsons/databases/redshift/rs_copy_table.py
@@ -19,12 +19,16 @@ class RedshiftCopyTable(object):
                        statupdate=True, compupdate=True, ignoreheader=1, acceptanydate=True,
                        dateformat='auto', timeformat='auto', emptyasnull=True,
                        blanksasnull=True, nullas=None, acceptinvchars=True, truncatecolumns=False,
-                       aws_access_key_id=None, aws_secret_access_key=None,
+                       specifycols=None, aws_access_key_id=None, aws_secret_access_key=None,
                        compression=None):
 
         # Source / Destination
         source = f's3://{bucket}/{key}'
-        sql = f"copy {table_name} \nfrom '{source}' \n"
+
+        # Add column list for mapping or if there are fewer columns on source file
+        col_list = f"({', '.join(specifycols)})" if specifycols is not None else ""
+
+        sql = f"copy {table_name}{col_list} \nfrom '{source}' \n"
 
         # Generate credentials
         sql += self.get_creds(aws_access_key_id, aws_secret_access_key)

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -162,6 +162,27 @@ class TestRedshift(unittest.TestCase):
                             "copy test_schema.test \nfrom 's3://buck/file.csv'",
                             "'aws_access_key_*id=HIDDEN*;aws_secret_access_key=*HIDDEN*'",
                             'emptyasnull', 'blanksasnull', 'acceptinvchars']
+
+        # Check that all of the expected options are there:
+        [self.assertNotEqual(sql.find(o), -1) for o in expected_options]
+
+    def test_copy_statement_columns(self):
+
+        cols = ['a', 'b', 'c']
+
+        sql = self.rs.copy_statement('test_schema.test', 'buck', 'file.csv',
+            aws_access_key_id='abc123', aws_secret_access_key='abc123', specifycols=cols)
+
+        # Scrub the keys
+        sql = re.sub(r'id=.+;', '*id=HIDDEN*;', re.sub(r"key=.+'", "key=*HIDDEN*'", sql))
+
+        print(sql)
+
+        expected_options = ['statupdate', 'compupdate', 'ignoreheader 1', 'acceptanydate',
+                            "dateformat 'auto'", "timeformat 'auto'", "csv delimiter ','",
+                            "copy test_schema.test(a, b, c) \nfrom 's3://buck/file.csv'",
+                            "'aws_access_key_*id=HIDDEN*;aws_secret_access_key=*HIDDEN*'",
+                            'emptyasnull', 'blanksasnull', 'acceptinvchars']
         for o in expected_options:
             print(o, sql.find(o))
 

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -155,17 +155,18 @@ class TestRedshift(unittest.TestCase):
             aws_access_key_id='abc123', aws_secret_access_key='abc123')
 
         # Scrub the keys
-        s = 'aws_access_key_id=[KEY];aws_secret_access_key=[KEY]'
-        sql = re.sub('=.+;|=.+', '=*HIDDEN*', s)
+        sql = re.sub(r'id=.+;', '*id=HIDDEN*;', re.sub(r"key=.+'", "key=*HIDDEN*'", sql))
 
-        expected_options = ['statupdate', 'compudate', 'ignoreheader 1', 'acceptanydate',
+        expected_options = ['statupdate', 'compupdate', 'ignoreheader 1', 'acceptanydate',
                             "dateformat 'auto'", "timeformat 'auto'", "csv delimiter ','",
                             "copy test_schema.test \nfrom 's3://buck/file.csv'",
-                            "'aws_access_key_id=*HIDDEN*;aws_secret_access_key=*HIDDEN*'",
-                            'emptyasnull', 'blankasnull', 'acceptinvchars']
+                            "'aws_access_key_*id=HIDDEN*;aws_secret_access_key=*HIDDEN*'",
+                            'emptyasnull', 'blanksasnull', 'acceptinvchars']
+        for o in expected_options:
+            print(o, sql.find(o))
 
         # Check that all of the expected options are there:
-        [self.assertNotEqual(sql.find(o), -1) for o in ['']]
+        [self.assertNotEqual(sql.find(o), -1) for o in expected_options]
 
 # These tests interact directly with the Redshift database
 


### PR DESCRIPTION
@jburchard opening a pull request because this might be the best venue to communicate about further testing. I've set up my tests with the following:

tables to be copied:
```
# Columns in same order as Redshift tables
copy_me = Table([
    {"integer": 1, "text": "one", "boolean": True, "manual_time": datetime.today()}
])
# Columns out of order
order_me = Table([
    {"text": "two", "boolean": False, "manual_time": datetime.today(), "integer": 2}
])
# Columns in order but meant for replacing data rather than appending
truncate_me = Table([
    {"integer": 3, "text": "three", "boolean": True, "manual_time": datetime.today()}
])
```
- Created Redshift table `tmc_scratch.copy_test_simple` with following columns
-- integer
-- text
-- boolean
-- manual_time
- Created Redshift table `tmc_scratch.copy_test_complex` with following columns
-- id (`IDENTITY(1,1)` and `DISTKEY` and `SORTKEY`)
-- all the columns from `copy_test_simple`
-- redshift_created_at (auto-populated timestamp)

I've tried the following tests:
- *Normal append to simple*: `copy_me.to_redshift('tmc_scratch.copy_test_simple', if_exists="append")` (Success)
- *Normal append to complex*: `copy_me.to_redshift('tmc_scratch.copy_test_complex', if_exists="append")` (Fail with expected error)
- *Append to complex with specifycols*: `copy_me.to_redshift('tmc_scratch.copy_test_complex', if_exists="append", specifycols=True)` (Success, random `id`, `redshift_created_at` good)
- *Disordered append to simple*: `order_me.to_redshift('tmc_scratch.copy_test_simple', if_exists="append")` (Fail with expected error)
- *Disordered append to simple with specifycols*: `order_me.to_redshift('tmc_scratch.copy_test_simple', if_exists="append", specifycols=True)` (Success)
- *Normal truncate to simple*: `truncate_me.to_redshift('tmc_scratch.copy_test_simple', if_exists="truncate")` (Success)
- *Normal truncate to complex*: `truncate_me.to_redshift('tmc_scratch.copy_test_complex', if_exists="truncate")` (Fail with expected error)
- *Truncate to complex with specifycols*: `truncate_me.to_redshift('tmc_scratch.copy_test_complex', if_exists="truncate", specifycols=True)` (Success, random `id`, `redshift_created_at` good)