### PR TITLE
Standardized Requests API Connector

### DIFF
--- a/parsons/ngpvan/activist_codes.py
+++ b/parsons/ngpvan/activist_codes.py
@@ -1,5 +1,6 @@
 """NGPVAN Activist Code Endpoints"""
 
+from parsons.etl.table import Table
 import logging
 logger = logging.getLogger(__name__)
 
@@ -27,12 +28,9 @@ class ActivistCodes(object):
 
         url = self.connection.uri + 'activistCodes'
 
-        logger.info(f'Getting activist codes...')
-        acs = self.connection.request_paginate(url)
-        logger.debug(acs)
-        logger.info(f'Found {acs.num_rows} activist codes.')
-
-        return acs
+        tbl = Table(self.connection.api.get_request(url))
+        logger.info(f'Found {tbl.num_rows} activist codes.')
+        return tbl
 
     def get_activist_code(self, activist_code_id):
         """Get an activist code
@@ -41,14 +39,11 @@ class ActivistCodes(object):
             activist_code_id : int
                 The activist code id associated with the activist code.
         `Returns:`
-            Parsons Table
-                See :ref:`parsons-table` for output options.
+            dict
         """
 
-        url = self.connection.uri + 'activistCodes/{}'.format(activist_code_id)
+        url = self.connection.uri + f'activistCodes/{activist_code_id}'
 
-        logger.info(f'Getting activist code {activist_code_id}...')
-        ac = self.connection.request(url)
-        logger.debug(ac)
+        r = self.connection.api.get_request(url)
         logger.info(f'Found activist code {activist_code_id}.')
-        return ac
+        return r

--- a/parsons/ngpvan/van_connector.py
+++ b/parsons/ngpvan/van_connector.py
@@ -2,6 +2,7 @@ from requests import request as _request
 from parsons.etl.table import Table
 import logging
 from parsons.utilities import check_env
+from parsons.utilities.api_connector import APIConnector
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,12 @@ class VANConnector(object):
         self.auth_name = auth_name
         self.raise_for_status = raise_for_status
         self.auth = (self.auth_name, self.api_key + '|' + str(self.db_code))
+
+        # Standardized API Connector. This is only being used by the get_activist_code methods
+        # but would like to roll out to the rest of the VAN methods in the future. Long term,
+        # would like to use for all classes in Parsons.
+        self.api = APIConnector(self.uri, auth=self.auth, data_key='items',
+                                pagination_key='nextPageLink')
 
     def _error_check(self, r):
 

--- a/parsons/utilities/api_connector.py
+++ b/parsons/utilities/api_connector.py
@@ -124,6 +124,9 @@ class APIConnector(object):
         Check to determine if there is a next page.
         """
 
+        # To Do: Some response jsons are enclosed in a list. Need to deal with unpacking and/or
+        # not assuming that it is going to be a dict.
+
         if self.pagination_key and self.pagination_key in resp.keys():
             if resp[self.pagination_key]:
                 return True

--- a/parsons/utilities/api_connector.py
+++ b/parsons/utilities/api_connector.py
@@ -37,6 +37,26 @@ class APIConnector(object):
     def request(self, url, req_type, json=None, data=None, params=None, raise_on_error=True):
         """
         Base request using requests libary.
+        
+        `Args:`
+            url: str
+                The url request string
+            req_type: str
+                The request type. One of GET, POST, PATCH, DELETE, OPTIONS
+            json: dict
+                The payload of the request object. By using json, it will automatically
+                serialize the dictionary
+            data: str or byte or dict
+                The payload of the request object. Use instead of json in some instances.
+            params: dict
+                The parameters to append to the url (e.g. http://myapi.com/things?id=1)
+            raise_on_error:
+                If the request yields an error status code (anything above 400), raise an
+                error. In most cases, this should be True, however in some cases, if you
+                are looping through data, you might want to ignore individual failures.
+        
+        `Returns:`
+            requests response
         """
 
         r = _request(req_type, url, headers=self.headers, auth=self.auth, json=None, data=None,
@@ -66,6 +86,8 @@ class APIConnector(object):
 
         r = self.request(url, req_type='GET', params=None)
 
+        # To Do: Implement better and more robust error handling method, but this
+        # will work for the time being.
         if raise_on_error:
             r.raise_for_status()
 
@@ -114,6 +136,9 @@ class APIConnector(object):
         data. This is useful in dealing with requests that might return multiple records, while
         others might return only a single record.
         """
+
+        # To Do: Some response jsons are enclosed in a list. Need to deal with unpacking and/or
+        # not assuming that it is going to be a dict.
 
         if self.data_key and self.data_key in resp.keys():
             return resp[self.data_key]

--- a/parsons/utilities/api_connector.py
+++ b/parsons/utilities/api_connector.py
@@ -1,0 +1,121 @@
+from requests import request as _request
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class APIConnector(object):
+    """
+    The API Connector is a low level class for API requests that other connectors
+    can utilize.
+
+    `Args:`
+        uri: str
+            The base uri for the api. Must include a trailing '/' (e.g. ``http://myapi.com/v1/``)
+        headers: dict
+            The request headers
+        auth: dict
+            The request authorization parameters
+        pagination_key: str
+            The name of the key in the response json where the pagination url is
+            located. Required for pagination.
+        data_key: str
+            The name of the key in the response json where the data is contained. Required
+            if the data is nested in the response json
+    `Returns`:
+        APIConnector class
+    """
+
+    def __init__(self, uri, headers=None, auth=None, pagination_key=None, data_key=None):
+
+        self.uri = uri
+        self.headers = headers
+        self.auth = auth
+        self.pagination_key = pagination_key
+        self.data_key = data_key
+
+    def request(self, url, req_type, json=None, data=None, params=None, raise_on_error=True):
+        """
+        Base request using requests libary.
+        """
+
+        r = _request(req_type, url, headers=self.headers, auth=self.auth, json=None, data=None,
+                     params=params)
+
+        if raise_on_error:
+            r.raise_for_status()
+
+        return r
+
+    def base_get_request(self, url, params=None, raise_on_error=True):
+        """
+        Args:
+            url: str
+                A complete and valid url for the api request
+            headers: dict
+                The header dict
+            auth: dict
+                The authentication dict
+            params: dict
+                The request parameters
+            raise_on_error: bool
+                Raise if status code returns an error
+        Returns:
+                A requests response object
+        """
+
+        r = self.request(url, req_type='GET', params=None)
+
+        if raise_on_error:
+            r.raise_for_status()
+
+        return r.json()
+
+    def get_request(self, endpoint, **kwargs):
+        """
+        Get request including pagination.
+
+        `Args:`
+            endpoint: str
+                The api endpoint. Add to the end of the uri to create a complete and
+                valid url.
+            **kwargs: args
+                Kwargs for the :meth:`APIConnector.base_get_request`
+        """
+
+        url = self.uri + endpoint
+
+        r = self.base_get_request(endpoint, **kwargs)
+
+        data = self.data_parse(r)
+
+        # Paginate
+        while self.next_page_check(r):
+            url = self.pagination_key
+            r = self.base_get_request(url, **kwargs)
+            data.extend(r.json[self.data_key])
+
+        return data
+
+    def next_page_check(self, resp):
+        """
+        Check to determine if there is a next page.
+        """
+
+        if self.pagination_key and self.pagination_key in resp.keys():
+            if resp[self.pagination_key]:
+                return True
+        else:
+            return False
+
+    def data_parse(self, resp):
+        """
+        Determines if the response json has nested data. If it is nested, it just returns the
+        data. This is useful in dealing with requests that might return multiple records, while
+        others might return only a single record.
+        """
+
+        if self.data_key and self.data_key in resp.keys():
+            return resp[self.data_key]
+        else:
+            return resp

--- a/parsons/utilities/api_connector.py
+++ b/parsons/utilities/api_connector.py
@@ -37,7 +37,7 @@ class APIConnector(object):
     def request(self, url, req_type, json=None, data=None, params=None, raise_on_error=True):
         """
         Base request using requests libary.
-        
+
         `Args:`
             url: str
                 The url request string
@@ -54,7 +54,7 @@ class APIConnector(object):
                 If the request yields an error status code (anything above 400), raise an
                 error. In most cases, this should be True, however in some cases, if you
                 are looping through data, you might want to ignore individual failures.
-        
+
         `Returns:`
             requests response
         """

--- a/test/test_van/test_ngpvan.py
+++ b/test/test_van/test_ngpvan.py
@@ -70,15 +70,7 @@ class TestNGPVAN(unittest.TestCase):
 
         m.get(self.van.connection.uri + 'activistCodes/4388538', json=json)
 
-        # Expected Structure
-        expected = ['status', 'scriptQuestion', 'name', 'mediumName',
-                    'activistCodeId', 'shortName', 'type', 'description']
-
-        # Assert response is expected structure
-        self.assertTrue(
-            validate_list(
-                expected,
-                self.van.get_activist_code(4388538)))
+        self.assertEqual(json, self.van.get_activist_code(4388538))
 
         # To Do: Test what happens when it doesn't find the AC
 


### PR DESCRIPTION
One of the original sins of this project was that we never established an underlying API connector class that wraps around the `requests` library. Most of our api connectors utilize `requests` and we written pagination and request in a custom manner for each api.

I propose that we should start moving towards, where possible this basic API connector class for all of our API requests.

**Concerns**
- If there is one thing that we have learned from this project is that there is not standardization across all apis. Pagination is handled in a dozen different ways.
- We should balance the development of this class and not try to overcomplicate it to deal with every weird API out there. That is, if an api is just totally weird, we might just want to build a custom connector.

**This PR**
- I'm starting with just `GET` requests and pagination for this PR.
- I've implemented it for just two methods of the VAN class.

**Moving Forward**
- I'd like to continue working on moving all of the VAN methods to this new connector. The VAN connector is a total mess, which was the original motivation for this PR.
- I need to add the `GET`, `PUT`, `DELETE` methods to this.

**Decision Points**
- I'd like this connector to always return a dict or a list of dicts. The connector class (e.g. VAN, Copper) should handle the conversion to a Parsons Table where appropriate (probably on the method level). Looking through the VAN Class, the decision to try to decide what needed to be a table and what didn't created some ugly code.

