### PR TITLE
Civis: Instantiate Class Improvement, Access Client

### DIFF
--- a/parsons/civis/civisclient.py
+++ b/parsons/civis/civisclient.py
@@ -8,20 +8,22 @@ class CivisClient(object):
     Instantiate the Civis class.
 
     `Args:`
-        api_key:
+        api_key: str
             The Civis api key.
-        db:
+        db: str or int
             The Civis Redshift database. Can be a database id or the name of the
             database.
+        **kwargs: args
+            Option settings for the client that are `described in the documentation <https://civis-python.readthedocs.io/en/stable/client.html#civis.APIClient>`_.
     `Returns:`
         Civis class
-    """
+    """  # noqa: E501
 
-    def __init__(self, db=None, api_key=None, resources='all'):
+    def __init__(self, db=None, api_key=None, **kwargs):
 
         self.api_key = check_env.check('CIVIS_API_KEY', api_key)
         self.db = check_env.check('CIVIS_DATABASE', db)
-        self.client = civis.APIClient(resources=resources)
+        self.client = civis.APIClient(api_key=api_key, **kwargs)
         """
         The Civis API client. Utilize this attribute to access to lower level and more
         advanced methods which might not be surfaced in Parsons. A list of the methods

--- a/parsons/civis/civisclient.py
+++ b/parsons/civis/civisclient.py
@@ -1,36 +1,33 @@
 import civis
 import os
 from parsons.etl.table import Table
+from parsons.utilities import check_env
 
 
 class CivisClient(object):
+    """
+    Instantiate the Civis class.
 
-    def __init__(self, db=None, api_key=None):
+    `Args:`
+        api_key:
+            The Civis api key.
+        db:
+            The Civis Redshift database. Can be a database id or the name of the
+            database.
+    `Returns:`
+        Civis class
+    """
 
-        if api_key is None:
+    def __init__(self, db=None, api_key=None, resources='all'):
 
-            try:
-                self.api_key = os.environ['CIVIS_API_KEY']
-            except KeyError:
-                raise KeyError('No Civis API key found. Please store'
-                               ' in environment variable or pass as an'
-                               'argument.')
-
-        if db is None:
-            try:
-                db = os.environ['CIVIS_DATABASE']
-            except KeyError:
-                raise KeyError('No Civis Database kwarg found. Please store'
-                               ' in environment variable or pass as an'
-                               'argument.')
-
-        if str(db).isdigit():
-            db = int(db)
-
-        self.db = db
-
-        if api_key:
-            os.environ['CIVIS_API_KEY'] = api_key
+        self.api_key = check_env.check('CIVIS_API_KEY', api_key)
+        self.db = check_env.check('CIVIS_DATABASE', db)
+        self.client = civis.APIClient(resources=resources)
+        """
+        The Civis API client. Utilize this attribute to access to lower level and more
+        advanced methods which might not be surfaced in Parsons. A list of the methods
+        can be found by reading the Civis API client `documentation <https://civis-python.readthedocs.io/en/stable/client.html>`_. 
+        """ # noqa: W605
 
     def query(self, sql, preview_rows=10, polling_interval=None, hidden=True,
               wait=True):

--- a/parsons/civis/civisclient.py
+++ b/parsons/civis/civisclient.py
@@ -1,5 +1,4 @@
 import civis
-import os
 from parsons.etl.table import Table
 from parsons.utilities import check_env
 
@@ -26,8 +25,8 @@ class CivisClient(object):
         """
         The Civis API client. Utilize this attribute to access to lower level and more
         advanced methods which might not be surfaced in Parsons. A list of the methods
-        can be found by reading the Civis API client `documentation <https://civis-python.readthedocs.io/en/stable/client.html>`_. 
-        """ # noqa: W605
+        can be found by reading the Civis API client `documentation <https://civis-python.readthedocs.io/en/stable/client.html>`_.
+        """  # noqa: E501
 
     def query(self, sql, preview_rows=10, polling_interval=None, hidden=True,
               wait=True):


### PR DESCRIPTION
- [ ] Removed custom error checking for the `env var` and moved to the standard Parsons utility.
- [ ] Added the ability to access the Civis client directly. This is helpful in allowing for access to low level methods which we may not surface in Parsons.

This PR is the first step in trying to build out more methods that are used in our internal scripts when we interact with Civis. Future PRs will include common methods that access the Civis client.