### PR TITLE
Remove documentation building packages from dependencies.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-python3.7-{{ checksum "requirements.txt" }}
+          - v1-dependencies-python3.7-{{ checksum "./docs/requirements.txt" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-python3.7-
       - run:
@@ -68,11 +68,11 @@ jobs:
             npm install -g --silent gh-pages@2.0.1
             python3 -m venv venv
             . venv/bin/activate
-            pip install -r requirements.txt
+            pip install -r ./docs/requirements.txt
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-python3.7-{{ checksum "requirements.txt" }}
+          key: v1-dependencies-python3.7-{{ checksum "./docs/requirements.txt" }}
       - add_ssh_keys:
           # This SSH key is the "CircleCI write key v2" in https://github.com/move-coop/parsons/settings/keys
           # We need write access to the Parsons repo, so we can push the "gh-pages" branch.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+Sphinx==1.8.3
+sphinx-rtd-theme==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ psycopg2-binary==2.7.6.1
 xmltodict==0.11.0
 gspread==3.1.0
 oauth2client==4.1.3
-Sphinx==1.8.3
-sphinx-rtd-theme==0.4.2
 facebook-business==4.0.3
 google-api-python-client==1.7.7
 google-auth==1.6.2


### PR DESCRIPTION
The `sphinx` packages that are used to build Parsons documentation were part of our standard requirements for the package. This was added an unneeded 50M in dependencies.

- Removed `sphinx` and `sphinx-rtd-theme` from `requirements.txt`
- Created a new `/docs/requirements.txt` that is called by CircleCI, when it is building the refreshed documentation. This is the only time that we need `sphinx`.