### PR TITLE
Remove Pandas requirement.

### DIFF
--- a/docs/table.rst
+++ b/docs/table.rst
@@ -21,9 +21,6 @@ From Parsons Table
     * - Method
       - Destination Type
       - Description
-    * - ``.to_dataframe()``
-      - Pandas Dataframe
-      - Return a Pandas dataframe
     * - ``.to_csv()``
       - CSV File
       - Write a table to a local csv file
@@ -51,6 +48,11 @@ From Parsons Table
     * - ``.to_html()``
       - HTML formatted table
       - Write a table to a local html file
+    * - ``.to_dataframe()``
+      - Pandas Dataframe [1]_
+      - Return a Pandas dataframe 
+
+.. [1] Requires optional installation of Pandas package by running ``pip install pandas``.
 
 ================
 To Parsons Table

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pandas==0.23.3
 requests==2.20.0
 petl==1.2.0
 boto3==1.9.25


### PR DESCRIPTION
Currently, we only us `pandas` only in order to allow tables to be converted to data frames. This is a really minor feature that we rarely, if ever, use. The creates dependencies in `pandas` and `numpy` which require 100M. It is contributing significantly to Parsons bloat.

I've removed the pandas dependency and noted in the documentation, that it is an optional dependency.