### PR TITLE
Fix Docs Requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+-r ../requirements.txt
 Sphinx==1.8.3
 sphinx-rtd-theme==0.4.2


### PR DESCRIPTION
The Sphinx document build was failing because it requires the Parsons dependencies installed to build out the website. This PR adds the Parsons requirements to the `./docs/requirements.txt`