### PR TITLE
VAN: Get Bulk Import Resources

### DIFF
--- a/docs/ngpvan.rst
+++ b/docs/ngpvan.rst
@@ -203,6 +203,12 @@ People
 .. autoclass:: parsons.ngpvan.van.People
    :inherited-members:
 
+***********
+Bulk Import
+***********
+.. autoclass:: parsons.ngpvan.van.BulkImport
+   :inherited-members:
+
 **************
 Activist Codes
 **************

--- a/parsons/ngpvan/bulk_import.py
+++ b/parsons/ngpvan/bulk_import.py
@@ -18,7 +18,7 @@ class BulkImport(object):
 
         `Returns:`
             list
-                A list of resources
+                A list of resources.
         """
 
         r = self.connection.get_request(f'bulkImportJobs/resources')

--- a/parsons/ngpvan/bulk_import.py
+++ b/parsons/ngpvan/bulk_import.py
@@ -12,7 +12,7 @@ class BulkImport(object):
 
     def get_bulk_import_resources(self):
         """
-        Get bulk import resources that avaliable to the user. These define
+        Get bulk import resources that available to the user. These define
         the types of bulk imports that you can run. These might include
         ``Contacts``, ``ActivistCodes``, ``ContactsActivistCodes`` and others.
 

--- a/parsons/ngpvan/bulk_import.py
+++ b/parsons/ngpvan/bulk_import.py
@@ -21,7 +21,6 @@ class BulkImport(object):
                 A list of resources
         """
 
-        url = self.connection.uri + 'bulkImportJobs/resources'
-        r = self.connection.request(url, raw=True)
-        logger.info(f'Bulk import resources: {r.json()}')
-        return r.json()
+        r = self.connection.get_request(f'bulkImportJobs/resources')
+        logger.info(f'Found {len(r)} bulk import resources.')
+        return r

--- a/parsons/ngpvan/bulk_import.py
+++ b/parsons/ngpvan/bulk_import.py
@@ -1,0 +1,27 @@
+"""NGPVAN Bulk Import Endpoints"""
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class BulkImport(object):
+
+    def __init__(self):
+
+        pass
+
+    def get_bulk_import_resources(self):
+        """
+        Get bulk import resources that avaliable to the user. These define
+        the types of bulk imports that you can run. These might include
+        ``Contacts``, ``ActivistCodes``, ``ContactsActivistCodes`` and others.
+
+        `Returns:`
+            list
+                A list of resources
+        """
+
+        url = self.connection.uri + 'bulkImportJobs/resources'
+        r = self.connection.request(url, raw=True)
+        logger.info(f'Bulk import resources: {r.json()}')
+        return r.json()

--- a/parsons/ngpvan/van.py
+++ b/parsons/ngpvan/van.py
@@ -11,6 +11,7 @@ from parsons.ngpvan.codes import Codes
 from parsons.ngpvan.scores import Scores, ScoreUpdates, FileLoadingJobs
 from parsons.ngpvan.signups import Signups
 from parsons.ngpvan.locations import Locations
+from parsons.ngpvan.bulk_import import BulkImport
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ logger = logging.getLogger(__name__)
 class VAN(People, Events, SavedLists, Folders, ExportJobs,
           ActivistCodes, CanvassResponses, SurveyQuestions,
           Codes, Scores, ScoreUpdates, FileLoadingJobs,
-          SupporterGroups, Signups, Locations):
+          SupporterGroups, Signups, Locations, BulkImport):
     """
     Returns the VAN class
 

--- a/parsons/ngpvan/van.py
+++ b/parsons/ngpvan/van.py
@@ -17,7 +17,8 @@ logger = logging.getLogger(__name__)
 
 
 class VAN(People, Events, SavedLists, Folders, ExportJobs, ActivistCodes, CanvassResponses,
-          SurveyQuestions, Codes, Scores, FileLoadingJobs, SupporterGroups, Signups, Locations):
+          SurveyQuestions, Codes, Scores, FileLoadingJobs, SupporterGroups, Signups, Locations,
+          BulkImport):
     """
     Returns the VAN class
 

--- a/test/test_van/test_bulkimport.py
+++ b/test/test_van/test_bulkimport.py
@@ -1,0 +1,26 @@
+import unittest
+import os
+import requests_mock
+from parsons.ngpvan.van import VAN
+
+os.environ['VAN_API_KEY'] = 'SOME_KEY'
+
+
+class TestBulkImport(unittest.TestCase):
+
+    def setUp(self):
+
+        self.van = VAN(os.environ['VAN_API_KEY'], db="MyVoters", raise_for_status=False)
+
+    def tearDown(self):
+
+        pass
+
+    @requests_mock.Mocker()
+    def test_get_bulk_import_resources(self, m):
+
+        json = ['Contacts', 'Contributions', 'ActivistCodes', 'ContactsActivistCodes']
+
+        m.get(self.van.connection.uri + 'bulkImportJobs/resources', json=json)
+
+        self.assertEqual(self.van.get_bulk_import_resources(), json)


### PR DESCRIPTION
The first PR of many in order to add the ability to access the bulk imports VAN end point.

`VAN.get_bulk_import_resources()` - Returns a list of resources (types of bulk imports) that have been provisioned to the API user.